### PR TITLE
eodudrepublic / 1월 5주차 / 2문제

### DIFF
--- a/eodudrepublic/2747_피보나치_수.py
+++ b/eodudrepublic/2747_피보나치_수.py
@@ -1,0 +1,33 @@
+import sys
+
+def fib_recursion(n) :
+    if n == 0 :
+        return 0
+    elif n == 1 :
+        return 1
+    else :
+        return fib_recursion(n-1) + fib_recursion(n-2)
+
+def fib():
+    x1 = 0
+    x2 = 1
+    def get_next_number():
+        nonlocal x1, x2
+        x3 = x1 + x2
+        x1, x2 = x2, x3
+        return x3
+    return get_next_number
+
+def fib_closure(n):
+    f = fib()
+    for i in range(2, n+1):
+        num = f()
+    return num
+
+n = int(sys.stdin.readline())
+if n == 0 :
+    print(0)
+elif n == 1 or n == 2 :
+    print(1)
+elif n > 2 :
+    print(fib_closure(n))

--- a/eodudrepublic/4150_피보나치_수.py
+++ b/eodudrepublic/4150_피보나치_수.py
@@ -1,0 +1,25 @@
+import sys
+
+def fib():
+    x1 = 0
+    x2 = 1
+    def get_next_number():
+        nonlocal x1, x2
+        x3 = x1 + x2
+        x1, x2 = x2, x3
+        return x3
+    return get_next_number
+
+def fib_closure(n):
+    f = fib()
+    for i in range(2, n+1):
+        num = f()
+    return num
+
+n = int(sys.stdin.readline())
+if n == 0 :
+    print(0)
+elif n == 1 or n == 2 :
+    print(1)
+elif n > 2 :
+    print(fib_closure(n))


### PR DESCRIPTION
[BOJ] 2747 피보나치 수 문제는 파이썬의 속도 문제로 (...) 재귀함수로 풀면 안될것 같아 클로저를 사용해 풀게 되었습니다. 하지만 이때 입력받는 n 값의 범위를 지정해 주지 않아 "런타임 에러 (UnboundLocalError)"이 떠 n의 범위를 지정해주었습니다.
알고리즘 분류는 수학과 구현입니다.
하지만 클로저를 사용해도 2시간 박고 파이썬으론 안된다며 포기했던 백준 1003번 피보나치 함수는 어떻게 풀어야 할지 모르겠네요... 허허...

[BOJ] 4150 피보나치 수 문제는 2747 문제와 똑같은 문제지만 왜 얘만 난이도가 더 높은지 모르겠는(...?) 문제입니다. 재귀 함수로 피보나치 구현할때는 풀 엄두가 안 나던 문제들인데 클로저를 사용하니 2문제 거저먹었네요.
알고리즘 분류는 임의 정밀도 / 큰 수 연산입니다.